### PR TITLE
Adjust labels

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -59,7 +59,15 @@
   description: ""
   color: "d73a4a"
 
-- name: "area/website"
+- name: "area/backend"
+  description: ""
+  color: "d73a4a"
+
+- name: "area/visual"
+  description: ""
+  color: "d73a4a"
+
+- name: "area/frontend"
   description: ""
   color: "d73a4a"
 

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -5,220 +5,220 @@
 
 - name: "area/abuse-vector"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/api"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/automation"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/cli"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/copy"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/documentation"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/exercises"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/markdown"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/mentor-tools"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/notifications"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/product"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/teams"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/track-maintenance"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/walkthrough"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/backend"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/visual"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "area/frontend"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "Hacktoberfest"
   description: ""
-  color: "d73a4a"
+  color: "ff7518"
 
 - name: "invalid"
   description: ""
-  color: "d73a4a"
+  color: "cccccc"
 
 - name: "priority/high"
   description: ""
-  color: "d73a4a"
+  color: "4DAA57"
 
 - name: "priority/low"
   description: ""
-  color: "d73a4a"
+  color: "B9DFBD"
 
 - name: "priority/medium"
   description: ""
-  color: "d73a4a"
+  color: "81C588"
 
 - name: "priority/next-up"
   description: ""
-  color: "d73a4a"
+  color: "337039"
 
 - name: "rgsoc-2018"
   description: ""
-  color: "d73a4a"
+  color: "ffffff"
 
 - name: "status/blocked"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/discussion"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/fixed"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/in-progress"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/needs-triaging"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/on-roadmap"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/pr-submitted"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/product-discussion"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/stale"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/triaged-to-repo"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "status/waiting-for-info"
   description: ""
-  color: "d73a4a"
+  color: "F8EBC9"
 
 - name: "todo/define-next-step"
   description: ""
-  color: "d73a4a"
+  color: "B5C8E3"
 
 - name: "todo/elaborate"
   description: ""
-  color: "d73a4a"
+  color: "B5C8E3"
 
 - name: "todo/move-to-correct-repo"
   description: ""
-  color: "d73a4a"
+  color: "B5C8E3"
 
 - name: "todo/please-summarize"
   description: ""
-  color: "d73a4a"
+  color: "B5C8E3"
 
 - name: "todo/rescue-me"
   description: ""
-  color: "d73a4a"
+  color: "B5C8E3"
 
 - name: "type/accessibility"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/announcement"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/bug"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/community-consultation"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/duplicate"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/feature-request"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/improvement"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/janitorial"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/mentoring-support"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/operations"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/policy"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/question"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/spam"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/support"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"
 
 - name: "type/wontfix"
   description: ""
-  color: "d73a4a"
+  color: "507DBC"


### PR DESCRIPTION
This replaces the `area/website` label with the more granular `area/frontend`, `area/backend`, and `area/visual`, as well as changing the label colors so that they're not all red. For the `rgsoc-2018` I picked white, and `hacktoberfest` I went with the  orange that we have for the sitewide `hacktoberfest-accepted` label.

I picked the colors kind of arbitrarily, and don't feel strongly about any of these choices.

`type/*`
<img width="100" alt="type-274268" src="https://user-images.githubusercontent.com/276834/159376796-2afbbaeb-7503-4edc-8af1-f96628b499a9.png">

`area/*`
<img width="72" alt="area-507DBC" src="https://user-images.githubusercontent.com/276834/159376714-5fea8a09-310b-4d36-ae1b-b801d73ad7b2.png">

`todo/*`
<img width="108" alt="todo-B5C8E3" src="https://user-images.githubusercontent.com/276834/159376827-ba5822aa-84a4-4406-a9c9-34cdbdc0b108.png">

`priority/next-up`
<img width="104" alt="priority-337039" src="https://user-images.githubusercontent.com/276834/159376882-cc8e3cc1-af4f-4cf1-b5c9-c076f2bb14e4.png">

`priority/high`
<img width="74" alt="priority-4DAA57" src="https://user-images.githubusercontent.com/276834/159376897-ef63a0e9-7d1a-4604-af90-69410ef4da28.png">

`priority/medium`
<img width="101" alt="priority-81C588" src="https://user-images.githubusercontent.com/276834/159376904-c281cfcc-2ee0-4017-b825-e12c44fd3814.png">

`priority/low`
<img width="104" alt="priority-B9DFBD" src="https://user-images.githubusercontent.com/276834/159376917-faa3ec56-455e-4729-9aa6-cd1a22be1064.png">

`status/*`
<img width="99" alt="status-F8EBC9" src="https://user-images.githubusercontent.com/276834/159376928-4a929fd2-6d94-42a4-a39d-81ccef59b94a.png">

