### PR TITLE
Fix labels (a bit more)

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -165,60 +165,60 @@
 
 - name: "type/accessibility"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/announcement"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/bug"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/community-consultation"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/duplicate"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/feature-request"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/improvement"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/janitorial"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/mentoring-support"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/operations"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/policy"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/question"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/spam"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/support"
   description: ""
-  color: "507DBC"
+  color: "1d3155"
 
 - name: "type/wontfix"
   description: ""
-  color: "507DBC"
+  color: "1d3155"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -132,7 +132,7 @@
   color: "F8EBC9"
 
 - name: "status/stale"
-  description: ""
+  description: "If marked as stale, issue will be closed after 7 days unless new information is provided."
   color: "F8EBC9"
 
 - name: "status/triaged-to-repo"


### PR DESCRIPTION
@iHiD and I spoke yesterday and decided to use the `status/stale` label to indicate that we think
something is no longer a problem. We will comment in the issue thread
when marking something as stale, asking people to double-check.

If we don't hear anything back, we will close the issue.
This is not an automated process at the moment.

I forgot to add this description in the previous PR :/

Also I messed up when assigning colors, and accidentally assigned the `area/*` color to the `type/*` labels as well. This updates the `type/*` labels to be darker.