### PR TITLE
Improve contrast for area/* labels

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -5,71 +5,71 @@
 
 - name: "area/abuse-vector"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/api"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/automation"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/cli"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/copy"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/documentation"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/exercises"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/markdown"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/mentor-tools"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/notifications"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/product"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/teams"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/track-maintenance"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/walkthrough"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/backend"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/visual"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "area/frontend"
   description: ""
-  color: "507DBC"
+  color: "4371b1"
 
 - name: "Hacktoberfest"
   description: ""


### PR DESCRIPTION
The blue that we chose for area/* automatically gets black text,
which is very difficult to read.

This darkens the blue a shade so that it gets white text.

Here's an example of the old label compared to what the new label will be with this pull request:
<img width="146" alt="Screen Shot 2022-03-23 at 5 59 20 PM" src="https://user-images.githubusercontent.com/276834/159815892-f481c957-b8fd-4a3b-844b-6a06e7699695.png">

And here's an example of what the labels will look like on the main issues page:
<img width="1219" alt="Screen Shot 2022-03-23 at 5 59 33 PM" src="https://user-images.githubusercontent.com/276834/159815957-08969fa2-354e-49ea-b79f-c26717f5b8f4.png">

