### PR TITLE
docs: coc section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you aren't sure where to open it, then pick this repository. It's as good a s
 
 ## Feeling uncomfortable?
 
-If you need to report a code of conduct violation, please email us at team@exercism.org.
+If you need to report a code of conduct violation, please email us at abuse@exercism.org and include \[CoC\] in the subject line. We will deal with all CoC issues as a priority.
 
 ## Where to find the code
 


### PR DESCRIPTION
On the websites contact us and abuse page, it uses this email address and requests that [CoC] be put in the subject.

Probably worth having that in the README as well?