### PR TITLE
docs: coc section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you aren't sure where to open it, then pick this repository. It's as good a s
 
 ## Feeling uncomfortable?
 
-If you need to report a code of conduct violation, please email us at team@exercism.org.
+If you need to report a code of conduct violation, please email us at [abuse@exercism.org](mailto:abuse@exercism.org?subject=%5BCoC%5D) and include \[CoC\] in the subject line. We will follow-up with you as a priority.
 
 ## Where to find the code
 


### PR DESCRIPTION
On the website's contact us and abuse page, it uses this email address and requests that [CoC] be put in the subject.

Probably worth having that in the README as well?

---

This was previous closed automatically. I believe I'm welcome to submit this now, though? ^-^'

> Yes, please update that
> 
> — https://github.com/exercism/exercism/issues/6352#issuecomment-1120443194

---

### Related
* https://github.com/exercism/org-wide-files/pull/220
  * I actually ask some questions here. Depending on the answers I may rebase and edit the commit, so it's best if that is reviewed first.